### PR TITLE
:opt: useless code remove

### DIFF
--- a/notion-zh_CN.js
+++ b/notion-zh_CN.js
@@ -640,30 +640,24 @@
     }
   }
 
-  setTimeout(() => {
-    window.requestIdleCallback(() => {
-      translate(NotionApp);
+  translate(NotionApp);
 
-      const observer = new MutationObserver(function(mutationsList) {
-        return window.requestIdleCallback(function() {
-          mutationsList = mutationsList.filter(MutationRecord => {
-            return MutationRecord.addedNodes.length !== 0;
-          }).map(MutationRecord => {
-            return MutationRecord.addedNodes;
-          });
-
-          for (let nodeList of mutationsList) {
-            for (let node of nodeList) {
-              translate(node);
-            }
-          }
-        });
+  const observer = new MutationObserver(function(mutationsList) {
+      mutationsList = mutationsList.filter(MutationRecord => {
+        return MutationRecord.addedNodes.length !== 0;
+      }).map(MutationRecord => {
+        return MutationRecord.addedNodes;
       });
 
-      observer.observe(NotionApp, {
-        childList: true,
-        subtree: true
-      });
-    });
+      for (let nodeList of mutationsList) {
+        for (let node of nodeList) {
+          translate(node);
+        }
+      }
+  });
+
+  observer.observe(NotionApp, {
+    childList: true,
+    subtree: true
   });
 })();


### PR DESCRIPTION
删除代码，原因有：

1. requestIdleCallback兼容性导致脚本在某些浏览器无法运行（例如safari）
2. 同步执行能够消除渲染闪烁（修改之前是会先显示英文，再显示翻译后的中文，就是因为被setTimeout调度到了首帧渲染之后）
3. 最主要的是这里异步延迟到空闲执行很没有必要，就算同步执行，也不会引起性能问题

综上，删除这些代码能获得更好的替换体验以及不明显的性能影响。

另：代码在chrome以及safari都进行了测试，应该没有什么问题。